### PR TITLE
Add support for gcs backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Role Variables
 * ```s3_access_key```
 * ```s3_secret_key```
 
+### GCS Storage
+
+* ```gcs_bucket```: Value for the bucket deing used.
+* ```gcs_storage_path```: The path within th ebucket where to store data. (will be created if not exist).
+* ```gcs_oauth2```: oauth2 value (default ```false```)
+* ```gcs_access_key```: only used when gcs_oauth2 is false.
+* ```gcs_secret_key```: only used when gcs_oauth2 is false.
+
 ## Note on SSL
 
 If using a self-signed certificate, or no SSL certificate for recent docker versions, you must start the docker daemon with ```--insecure-registry```.

--- a/tasks/base.yml
+++ b/tasks/base.yml
@@ -44,6 +44,10 @@
   copy: src=docker-registry.init dest=/etc/init/docker-registry.conf owner=root group=root mode=644
   tags: base
 
+- name: Install gcs backend driver.
+  pip: name=https://github.com/GoogleCloudPlatform/docker-registry-driver-gcs/zipball/master
+  when: storage_type == 'gcs'
+
 - name: Ensure Docker Registry is enabled and running
   service: name=docker-registry state=running enabled=yes
   tags: base

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -40,7 +40,20 @@ s3: &s3
     s3_access_key: _env:AWS_KEY:{{ s3_access_key }}
     s3_secret_key: _env:AWS_SECRET:{{ s3_secret_key }}
 {% endif %}
- 
+
+{% if storage_type == 'gcs' %}
+gcs: &gcs
+   <<: *common
+   storage: gcs
+   boto_bucket: _env:GCS_BUCKET:{{ gcs_bucket }}
+{% if gcs_oauth2 is defined and gcs_oauth2  %}
+   oauth2: {{ gcs_oauth2 }}
+{% else %}
+   gs_access_key: _env:GCS_KEY:{{ gcs_access_key }}
+   gs_secret_key: _env:GCS_SECRET:{{ gcs_secret_key }}
+{% endif %}
+   storage_path: _env:STORAGE_PATH:{{ gcs_storage_path }}
+{% endif %}
 
 prod:
   <<: *{{storage_type }}


### PR DESCRIPTION
This patch allows to configure the docker registry with the GCS backend.
For this we need to:
- Install the official GCS backend driver since unlike AWS one it is not shipped with the docker
  registry package. (repo: https://github.com/GoogleCloudPlatform/docker-registry-driver-gcs)
- Add the necessary options in the registry configuration file.

GCS driver backend for docker allows several kind of authentication.
This patch add support for oauth2 and key based authentication.
