### PR TITLE
Extend role to use a google service account for authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,21 @@ Role Variables
 
 * ```gcs_bucket```: Value for the bucket deing used.
 * ```gcs_storage_path```: The path within th ebucket where to store data. (will be created if not exist).
+
+#### There are 3 ways to specify credentials for GCS storage:
+
+**1. Using Google Cloud Platform OAuth:**
+
 * ```gcs_oauth2```: oauth2 value (default ```false```)
-* ```gcs_access_key```: only used when gcs_oauth2 is false.
-* ```gcs_secret_key```: only used when gcs_oauth2 is false.
+
+**2. Using Google Storage interoperability keys:**
+
+* ```gcs_access_key```: only used when gcs_oauth2 is false and ```use_gcs_default_credentials``` is undefined.
+* ```gcs_secret_key```: only used when gcs_oauth2 is false and ```use_gcs_default_credentials``` is undefined.
+
+**3. Using Google service account authorization:**
+
+* ```use_gcs_default_credentials```: use a service account that has been attached to that virtual machine for [authorisation](https://developers.google.com/identity/protocols/application-default-credentials) value (default ```undefined```)
 
 ## Note on SSL
 

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -48,6 +48,13 @@ gcs: &gcs
    boto_bucket: _env:GCS_BUCKET:{{ gcs_bucket }}
 {% if gcs_oauth2 is defined and gcs_oauth2  %}
    oauth2: {{ gcs_oauth2 }}
+{% elif use_gcs_default_credentials is defined %}
+   # No oauth2 or [gcs_access_key|gcs_secret_key] let us use a service account
+   # that is connected to the virtual machine instance see Google Application
+   # Default Credentials (see
+   # https://developers.google.com/identity/protocols/application-default-credentials)
+   # to allow the docker registry to get its authorisation credentials by making
+   # google api calls.
 {% else %}
    gs_access_key: _env:GCS_KEY:{{ gcs_access_key }}
    gs_secret_key: _env:GCS_SECRET:{{ gcs_secret_key }}


### PR DESCRIPTION
**What**

The current implementation of this playbook only supports 2 of the 3 options for accessing storage buckets i.e.:
- `oauth2`,
- Interoperability keys - `gcs_access_key` and `gcs_secret_key`.

The purpose of this PR is to add support for the third option:
- Using a google service account for [authorization](https://developers.google.com/identity/protocols/application-default-credentials)

**Testing**

We have tested this playbook with postiive and negative conditions to ensure there are adverse side effects.
