### PR TITLE
Allow S3 keys to be omitted for instance profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ Role Variables
 * ```s3_access_key```
 * ```s3_secret_key```
 
+#### There are 2 ways to specify credentials for S3 storage:
+
+**1. Using access and secret keys:**
+
+By specifying ```s3_access_key``` and ```s3_secret_key```.
+
+**2. Using IAM instance profiles**
+
+By omitting ```s3_access_key``` and ```s3_secret_key``` it will use an IAM instance profile that has been attached to that virtual machine for [authorisation](http://docs.aws.amazon.com/IAM/latest/UserGuide/roles-usingrole-ec2instance.html).
+
 ### GCS Storage
 
 * ```gcs_bucket```: Value for the bucket deing used.

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -37,8 +37,14 @@ s3: &s3
     s3_encrypt: _env:AWS_ENCRYPT:true
     s3_secure: _env:AWS_SECURE:true
     boto_bucket: _env:AWS_BUCKET:{{ s3_bucket }}
+{% if s3_access_key is defined and s3_secret_key is defined %}
     s3_access_key: _env:AWS_KEY:{{ s3_access_key }}
     s3_secret_key: _env:AWS_SECRET:{{ s3_secret_key }}
+{% else %}
+    # No [s3_access_key|s3_secret_key] lets us use an IAM instance profile
+    # that is attached to the virtual machine. See:
+    # http://docs.aws.amazon.com/IAM/latest/UserGuide/roles-usingrole-ec2instance.html
+{% endif %}
 {% endif %}
 
 {% if storage_type == 'gcs' %}


### PR DESCRIPTION
Allow the `s3_access_key` and `s3_secret_key` variables to be omitted and
not rendered into the configuration, which allows Docker Registry (and Boto
underneath) to use IAM instance profiles.

This is similar to 799f209 for GCS. However, I'm not providing a separate
variable to enable this, because there are only two options and the naming
(default credentials) wouldn't match the GCS implementation.
