### PR TITLE
Add support for version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Role Variables
 * ```storage_path```: File path to store registry uploads (default: ```/var/docker-registry```)
 * ```use_nginx```: Install Nginx and configure docker-registry vhost (default: ```true```)
 * ```use_redis```: Install and configure Redis server as a cache (default: ```true```)
+* ```docker_registry_version```: Specify what version of docker_registry needs to be installed (default: ```none```)
 
 ### SSL Settings
 * ```registry_port```: Custom port to have nginx listen on (default: ```80```)

--- a/tasks/base.yml
+++ b/tasks/base.yml
@@ -14,8 +14,14 @@
     - swig
   tags: base
 
-- name: Install Docker Registry
+- name: Install latest version of Docker Registry
   pip: name=docker-registry state=present
+  when: docker_registry_version is not defined
+  tags: base
+
+- name: Install a specific version of Docker Registry
+  pip: name=docker-registry state=present version={{ docker_registry_version }}
+  when: docker_registry_version is defined
   tags: base
 
 - name: Create required directories


### PR DESCRIPTION
Add support for version pinning of docker_registry

**What**

Add support for pinning down the specific version of the docker_registry.

**How this PR should be reviewed**

I've created the PR so it should be easy to test and review in a Vagrant box, things to note however are that I am passing `extra_args='-v'` as part of the `if docker_registry_version is defined` block.

The reason why I am doing this is because arguments supplied to `pip:` are stored in an array and when I start the `if` block an empty element is created and unless it is filled with something e.g. `extra_args='-v'` it will cause ansible to error 
